### PR TITLE
remove empty required vars

### DIFF
--- a/add-ons/management-infra/management-infra.addon
+++ b/add-ons/management-infra/management-infra.addon
@@ -1,6 +1,5 @@
 # Name: management-infra
 # Description: Creates management objects for ManageIQ, Cloudforms, etc
-# Required-Vars: 
 
 echo Creating management-infra project
 oc new-project management-infra --description="Management Infrastructure" --as=system:admin


### PR DESCRIPTION
Fix #49 
with that empty line minishift would throw the error

```
❯ minishift addon apply management-infra

-- Applying addon 'management-infra':Error applying the add-on: The variable(s)  are required by the add-on, but are not defined in the context
```

or make [this check](https://github.com/minishift/minishift/blob/c1fd618c40452a9029c6ad7c7b7912d6f3e7901f/pkg/minishift/addon/manager/addon_manager.go#L296) more error prone
