### PR TITLE
minishift-addons #62: Workaround for OpenShift 3.7.0 since using --as=developer option results in 'You may not request a new project via this API'

### DIFF
--- a/add-ons/che/che.addon
+++ b/add-ons/che/che.addon
@@ -8,8 +8,10 @@ oc apply -f streams/che-server-streams.json -n openshift
 echo [CHE] Create the Che server Template
 oc apply -f templates/che-single-user.yml -n openshift
 
-echo [CHE] Creating mini-che project
-oc new-project mini-che --description="Eclipse Che on minishift" --as=developer
+echo [CHE] Creating mini-che project as developer
+oc login -u developer -p developer
+oc new-project mini-che --description="Eclipse Che on minishift"
+oc login -u system:admin
 
 echo [CHE] Switching to mini-che...
 oc project mini-che


### PR DESCRIPTION
verified against the following `minishift openshift version`
```
openshift v3.7.0-rc.0+e92d5c5
kubernetes v1.7.6+a08f5eeb62
etcd 3.2.8
```
