### PR TITLE
Let's not use the LATEST image tag

### DIFF
--- a/add-ons/debezium/debezium.addon
+++ b/add-ons/debezium/debezium.addon
@@ -1,7 +1,7 @@
 # Name: debezium
 # Description: Deploys a Kafka Cluster and a Connect cluster with Debezium
 # Required-Vars: DEBEZIUM_VERSION,DEBEZIUM_PLUGIN,PROJECT,STRIMZI_RELEASE
-# Var-Defaults: STRIMZI_RELEASE=0.1.0,STRIMZI_REPO_NAME=strimzi,STRIMZI_IMAGE_TAG=latest,PROJECT=debezium
+# Var-Defaults: STRIMZI_RELEASE=0.1.0,STRIMZI_REPO_NAME=strimzi,STRIMZI_IMAGE_TAG=0.1.0,PROJECT=debezium
 
 # Pull images
 echo Pulling images...


### PR DESCRIPTION
We are already using the `STRIMZI_RELEASE` with `0.1.0` release. For the images of the _Strimzi_ project we must use the same version, instead of `LATEST` 