### PR TITLE
Issue #86: use Che 5 specific images instead of latest by default

### DIFF
--- a/add-ons/che/che.addon
+++ b/add-ons/che/che.addon
@@ -2,7 +2,7 @@
 # Description: Setup and Configure Eclipse Che Template and Image Streams
 # Url: https://www.eclipse.org/che/docs/setup/openshift/index.html
 # Required-Vars: NAMESPACE, CHE_DOCKER_IMAGE, OPENSHIFT_TOKEN, GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET
-# Var-Defaults: NAMESPACE=mini-che, CHE_DOCKER_IMAGE=eclipse/che-server:latest, OPENSHIFT_TOKEN="changeme", GITHUB_CLIENT_ID="changeme", GITHUB_CLIENT_SECRET="changeme"
+# Var-Defaults: NAMESPACE=mini-che, CHE_DOCKER_IMAGE=eclipse/che-server:5.22.1, OPENSHIFT_TOKEN="changeme", GITHUB_CLIENT_ID="changeme", GITHUB_CLIENT_SECRET="changeme"
 # OpenShift-Version: >=3.5.0
 
 echo [CHE] Create the Che server Template

--- a/add-ons/che/che.addon.remove
+++ b/add-ons/che/che.addon.remove
@@ -4,11 +4,11 @@
 # Required-Vars: NAMESPACE
 # Var-Defaults: NAMESPACE=mini-che
 
-echo [CHE] Removing Che server Template 
+echo [CHE] Removing Che server Template
 oc delete -f templates/che-single-user.yml -n openshift
 
 echo [CHE] Removing #{NAMESPACE} project
 oc delete project #{NAMESPACE}
 oc adm policy remove-role-from-user system:image-builder developer -n openshift
 
-echo Eclipse Che addon removed  
+echo Eclipse Che addon removed

--- a/add-ons/che/templates/che-single-user.yml
+++ b/add-ons/che/templates/che-single-user.yml
@@ -24,14 +24,14 @@ parameters:
   - displayName: Che Server Image
     description: The docker image to be used for che.
     name: IMAGE_CHE_SERVER
-    value: "eclipse/che-server:latest"
+    value: "eclipse/che-server:5.22.1"
     required: false
   - displayName: OpenShift OAuth Token
-    description: Token to get access to the OpenShift API 
+    description: Token to get access to the OpenShift API
     name: OPENSHIFT_OAUTH_TOKEN
     value: ""
   - displayName: GitHub client ID
-    description: GitHub client ID  
+    description: GitHub client ID
     name: GITHUB_CLIENT_ID
     value: ""
   - displayName: GitHub client secret


### PR DESCRIPTION
Use Che 5 specific image by default because latest Che image moved to Che6.
It is still possible to run Che 6 with the same flow as described in Che addon readme file.

After this PR addon works by default but doesn't get updates of Che 5. I created an issue in Che to tag latest Che 5 image https://github.com/eclipse/che/issues/8751. After this, it will be possible to change approach in the Che addon.

Fixes #86 