### PR TITLE
make registry type configurable via dynamic variables

### DIFF
--- a/add-ons/ansible-service-broker/README.md
+++ b/add-ons/ansible-service-broker/README.md
@@ -60,6 +60,9 @@ To customize the deployment of the Ansible Service Broker, the following variabl
 |`BROKER_REPO_TAG`|Tag used to specify the broker's template in the upstream asb repo|`ansible-service-broker-1.1.6-1`|
 |`APBTOOLS_REPO_TAG`|Tag used to specify the apb tooling permission template in the upstream apb repo|`apb-1.1.6-1`|
 |`DOCKERHUB_ORG`|Organization to query for Ansible Playbook Bundles in DockerHub|`ansibleplaybookbundle`|
+|`REGISTRY_TYPE`|Registry type for Ansible Playbook Bundles (e.g. dockerhub, rhcc)|`dockerhub`|
+|`REGISTRY_NAME`|Registry name to query for Ansible Playbook Bundles (e.g. dh, rh)|`dh`|
+|`REGISTRY_URL`|Registry URL for Ansible Playbook Bundles|`https://registry.hub.docker.com`|
 
 Variables can be specified by adding `--addon-env <key=value>` when the addon is being invoked (`minishift start` or `minishift addons apply`)
 

--- a/add-ons/ansible-service-broker/ansible-service-broker.addon
+++ b/add-ons/ansible-service-broker/ansible-service-broker.addon
@@ -1,8 +1,8 @@
 # Name: ansible-service-broker
 # Description: Deploys the Ansible Service Broker
 # OpenShift-Version: >=3.7.0
-# Required-Vars: BROKER_REPO_TAG, APBTOOLS_REPO_TAG, DOCKERHUB_ORG
-# Var-Defaults: BROKER_REPO_TAG=ansible-service-broker-1.1.8-1, APBTOOLS_REPO_TAG=apb-1.1.6-1, DOCKERHUB_ORG=ansibleplaybookbundle
+# Required-Vars: BROKER_REPO_TAG, APBTOOLS_REPO_TAG, DOCKERHUB_ORG, REGISTRY_TYPE, REGISTRY_NAME, REGISTRY_URL
+# Var-Defaults: BROKER_REPO_TAG=ansible-service-broker-1.1.8-1, APBTOOLS_REPO_TAG=apb-1.1.6-1, DOCKERHUB_ORG=ansibleplaybookbundle, REGISTRY_TYPE=dockerhub, REGISTRY_NAME=dh, REGISTRY_URL=https://registry.hub.docker.com
 
 # Create ansible-service-broker project
 oc new-project ansible-service-broker
@@ -19,7 +19,7 @@ docker exec origin /bin/bash -c $'yum install -y openssl'
 docker exec origin /bin/bash -c $'mkdir -p /tmp/etcd-cert'
 docker exec origin /bin/bash -c $'openssl req -nodes -x509 -newkey rsa:4096 -keyout /tmp/etcd-cert/key.pem -out /tmp/etcd-cert/cert.pem -days 365 -subj "/CN=asb-etcd.ansible-service-broker.svc"'
 docker exec origin /bin/bash -c $'openssl genrsa -out /tmp/etcd-cert/MyClient1.key 2048 && openssl req -new -key /tmp/etcd-cert/MyClient1.key -out /tmp/etcd-cert/MyClient1.csr -subj "/CN=client" && openssl x509 -req -in /tmp/etcd-cert/MyClient1.csr -CA /tmp/etcd-cert/cert.pem -CAkey /tmp/etcd-cert/key.pem -CAcreateserial -out /tmp/etcd-cert/MyClient1.pem -days 1024'
-docker exec origin /bin/bash -c $'oc process ansible-service-broker -n ansible-service-broker -p DOCKERHUB_ORG=#{DOCKERHUB_ORG} -p ROUTING_SUFFIX=#{routing-suffix} -p ETCD_TRUSTED_CA_FILE=/var/run/etcd-auth-secret/ca.crt -p BROKER_CLIENT_CERT_PATH=/var/run/asb-etcd-auth/client.crt -p BROKER_CLIENT_KEY_PATH=/var/run/asb-etcd-auth/client.key -p ETCD_TRUSTED_CA="$(base64 /tmp/etcd-cert/cert.pem)" -p BROKER_CLIENT_CERT="$(base64 /tmp/etcd-cert/MyClient1.pem)" -p BROKER_CLIENT_KEY="$(base64 /tmp/etcd-cert/MyClient1.key)" -p BROKER_CA_CERT=$(oc get secret -n kube-service-catalog -o go-template=\'{{ range .items }}{{ if eq .type \"kubernetes.io/service-account-token\" }}{{ index .data \"service-ca.crt\" }}{{end}}{{\"\\n\"}}{{end}}\' | tail -n 1) | oc create -n ansible-service-broker -f-'
+docker exec origin /bin/bash -c $'oc process ansible-service-broker -n ansible-service-broker -p DOCKERHUB_ORG=#{DOCKERHUB_ORG} -p ROUTING_SUFFIX=#{routing-suffix} -p ETCD_TRUSTED_CA_FILE=/var/run/etcd-auth-secret/ca.crt -p BROKER_CLIENT_CERT_PATH=/var/run/asb-etcd-auth/client.crt -p BROKER_CLIENT_KEY_PATH=/var/run/asb-etcd-auth/client.key -p ETCD_TRUSTED_CA="$(base64 /tmp/etcd-cert/cert.pem)" -p BROKER_CLIENT_CERT="$(base64 /tmp/etcd-cert/MyClient1.pem)" -p BROKER_CLIENT_KEY="$(base64 /tmp/etcd-cert/MyClient1.key)" -p BROKER_CA_CERT=$(oc get secret -n kube-service-catalog -o go-template=\'{{ range .items }}{{ if eq .type \"kubernetes.io/service-account-token\" }}{{ index .data \"service-ca.crt\" }}{{end}}{{\"\\n\"}}{{end}}\' | tail -n 1) -p REGISTRY_TYPE=#{REGISTRY_TYPE} -p REGISTRY_NAME=#{REGISTRY_NAME} -p REGISTRY_URL=#{REGISTRY_URL} | oc create -n ansible-service-broker -f-'
 docker exec origin /bin/bash -c $'oc process apbtools-permission -n ansible-service-broker | oc create -f-'
 
 echo Ansible Service Broker Deployed


### PR DESCRIPTION
Currently the ASB addon will grab APB images from the upstream dockerhub repo/org.  Adding the following as a dynamic variable allows the user to configure another registry type via '--addon-env'. 
 - REGISTRY_TYPE
 - REGISTRY_NAME
 - REGISTRY_URL
