### PR TITLE
Update ansible-service-broker addon as of minishift v1.16.1

### DIFF
--- a/add-ons/ansible-service-broker/README.md
+++ b/add-ons/ansible-service-broker/README.md
@@ -6,14 +6,18 @@ is an Open Service Broker designed to deploy [Ansible Playbook Bundles](https://
 
 # Prerequisites
 
-This addon is designed for an RBAC enabled OpenShift cluster of `>=3.7`. Minishift can be configured to
-deploy 3.7 with the following command:
+This addon is designed for an RBAC enabled OpenShift cluster of `>=3.9`. Minishift can be configured to
+deploy 3.9 with the following command:
 
 ```
-$ minishift config set openshift-version v3.7.1
+$ minishift config set openshift-version v3.9.0
 ```
 
 Minishift must be deployed with the Service Catalog enabled
+
+**NOTE**: Prior to minishift `v1.16.1`, minishift was installed with the Service
+Catalog in a different way. These instructions are for minishift `>=v1.16.1`,
+and it is strongly recommended that this version or greater is used.
 
 The Service Catalog can be deployed by adding the `--service-catalog` when starting Minishift. The ability to pass extra flags during startup can be enabled by setting the _MINISHIFT_ENABLE_EXPERIMENTAL_ environmental variable as follows:
 
@@ -30,10 +34,10 @@ $ minishift config set iso-url centos
 
 Note: CentOS ISO is required for Fedora, CentOS, or RHEL hosts due to a [known issue](https://docs.openshift.org/latest/minishift/troubleshooting/troubleshooting-misc.html#authentication-required-to-push-image) between the host's docker client and the default boot2docker iso.
 
-Start Minishift with the `--service-catalog` flag
+Start Minishift with the `--service-catalog` extra flag. See the [OpenShift documentation](https://docs.openshift.org/latest/minishift/using/experimental-features.html#enabling-experimental-oc-flags) for more info on `--extra-cluster-up` flags.
 
 ```
-$ minishift start --service-catalog
+minishift start --extra-clusterup-flags "--service-catalog"
 ```
 
 

--- a/add-ons/ansible-service-broker/ansible-service-broker.addon
+++ b/add-ons/ansible-service-broker/ansible-service-broker.addon
@@ -1,8 +1,8 @@
 # Name: ansible-service-broker
 # Description: Deploys the Ansible Service Broker
-# OpenShift-Version: >=3.7.0
+# OpenShift-Version: >=3.9.0
 # Required-Vars: BROKER_REPO_TAG, APBTOOLS_REPO_TAG, DOCKERHUB_ORG
-# Var-Defaults: BROKER_REPO_TAG=ansible-service-broker-1.1.8-1, APBTOOLS_REPO_TAG=apb-1.1.6-1, DOCKERHUB_ORG=ansibleplaybookbundle
+# Var-Defaults: BROKER_REPO_TAG=ansible-service-broker-1.2.9-1, APBTOOLS_REPO_TAG=release-1.1, DOCKERHUB_ORG=ansibleplaybookbundle
 
 # Create ansible-service-broker project
 oc new-project ansible-service-broker
@@ -11,15 +11,8 @@ oc new-project ansible-service-broker
 oc create -n ansible-service-broker -f https://raw.githubusercontent.com/openshift/ansible-service-broker/#{BROKER_REPO_TAG}/templates/deploy-ansible-service-broker.template.yaml
 oc create -n ansible-service-broker -f https://raw.githubusercontent.com/ansibleplaybookbundle/ansible-playbook-bundle/#{APBTOOLS_REPO_TAG}/templates/openshift-permissions.template.yaml
 
-# Instantiate Template
-## Wrap in Docker Exec
-## First Handle Varaiables and set sensible defaults
-## Instantiate Template
-docker exec origin /bin/bash -c $'yum install -y openssl'
-docker exec origin /bin/bash -c $'mkdir -p /tmp/etcd-cert'
-docker exec origin /bin/bash -c $'openssl req -nodes -x509 -newkey rsa:4096 -keyout /tmp/etcd-cert/key.pem -out /tmp/etcd-cert/cert.pem -days 365 -subj "/CN=asb-etcd.ansible-service-broker.svc"'
-docker exec origin /bin/bash -c $'openssl genrsa -out /tmp/etcd-cert/MyClient1.key 2048 && openssl req -new -key /tmp/etcd-cert/MyClient1.key -out /tmp/etcd-cert/MyClient1.csr -subj "/CN=client" && openssl x509 -req -in /tmp/etcd-cert/MyClient1.csr -CA /tmp/etcd-cert/cert.pem -CAkey /tmp/etcd-cert/key.pem -CAcreateserial -out /tmp/etcd-cert/MyClient1.pem -days 1024'
-docker exec origin /bin/bash -c $'oc process ansible-service-broker -n ansible-service-broker -p DOCKERHUB_ORG=#{DOCKERHUB_ORG} -p ROUTING_SUFFIX=#{routing-suffix} -p ETCD_TRUSTED_CA_FILE=/var/run/etcd-auth-secret/ca.crt -p BROKER_CLIENT_CERT_PATH=/var/run/asb-etcd-auth/client.crt -p BROKER_CLIENT_KEY_PATH=/var/run/asb-etcd-auth/client.key -p ETCD_TRUSTED_CA="$(base64 /tmp/etcd-cert/cert.pem)" -p BROKER_CLIENT_CERT="$(base64 /tmp/etcd-cert/MyClient1.pem)" -p BROKER_CLIENT_KEY="$(base64 /tmp/etcd-cert/MyClient1.key)" -p BROKER_CA_CERT=$(oc get secret -n kube-service-catalog -o go-template=\'{{ range .items }}{{ if eq .type \"kubernetes.io/service-account-token\" }}{{ index .data \"service-ca.crt\" }}{{end}}{{\"\\n\"}}{{end}}\' | tail -n 1) | oc create -n ansible-service-broker -f-'
+## Instantiate Template, wrap in docker execs
+docker exec origin /bin/bash -c $'oc process ansible-service-broker -n ansible-service-broker -p BROKER_IMAGE=ansibleplaybookbundle/origin-ansible-service-broker:#{BROKER_REPO_TAG} -p DOCKERHUB_ORG=#{DOCKERHUB_ORG} -p ROUTING_SUFFIX=#{routing-suffix} -p BROKER_CA_CERT=$(oc get secret -n kube-service-catalog -o go-template=\'{{ range .items }}{{ if eq .type \"kubernetes.io/service-account-token\" }}{{ index .data \"service-ca.crt\" }}{{end}}{{\"\\n\"}}{{end}}\' | tail -n 1) | oc create -n ansible-service-broker -f-'
 docker exec origin /bin/bash -c $'oc process apbtools-permission -n ansible-service-broker | oc create -f-'
 
 echo Ansible Service Broker Deployed

--- a/add-ons/ansible-service-broker/ansible-service-broker.addon.remove
+++ b/add-ons/ansible-service-broker/ansible-service-broker.addon.remove
@@ -1,8 +1,8 @@
 # Name: ansible-service-broker
 # Description: Removes the Ansible Service Broker
-# OpenShift-Version: >=3.7.0
+# OpenShift-Version: >=3.9.0
 # Required-Vars: BROKER_REPO_TAG, APBTOOLS_REPO_TAG
-# Var-Defaults: BROKER_REPO_TAG=ansible-service-broker-1.1.8-1, APBTOOLS_REPO_TAG=apb-1.1.6-1
+# Var-Defaults: BROKER_REPO_TAG=ansible-service-broker-1.2.8-1, APBTOOLS_REPO_TAG=release-1.1
 
 oc delete clusterrolebinding asb-auth-bind
 oc delete clusterrolebinding asb


### PR DESCRIPTION
Minishift v1.16.1 removed the `--service-catalog` flag, which our broker depends upon. This PR updates instructions for usage with new minishift versions, as well as updates the addon to use our newly released deployment scripts.

As a bonus, the broker is now using CRDs as its standard persistence layer, so the previous cert generation details are no longer required as the broker does not bring its own etcd instance any longer.