### PR TITLE
Ability to configure htpasswd based identity provider for openshift

### DIFF
--- a/add-ons/htpasswd-identity-provider/README.adoc
+++ b/add-ons/htpasswd-identity-provider/README.adoc
@@ -1,0 +1,87 @@
+:linkattrs:
+
+= htpasswd-identity-provider
+
+This add-on configures OpenShift to use HTPasswordIdentityProvider.  For more info on the Identity Providers refer to https://docs.openshift.org/3.9/install_config/configuring_authentication.html
+
+WARNING: This addon works only for CentOS based minishift instances
+
+== Add-on Variables
+
+The following list of variables can be used while configuring the add-on:
+
+[%header,cols=3] 
+|===
+|Variable Name
+|Description
+|Default value
+
+|MINISHFIT_DATA_HOME
+|The minishift data directory within the vm instance
+|/var/lib/minishift
+
+|CONFIG_LOCATION
+|The openshift master configuration folder
+|openshift.local.config/master
+
+|MASTER_CONFIG_FILE
+|The openshift master configuration file name
+|master-config.yaml
+
+|USERNAME
+|The username that will be added to users.htpasswd file
+|developer
+
+|USER_PASSWORD^*^
+|This **mandatory** variable sets password to the user specified via **USERNAME**.  If the **USERNAME** variable is not specified this sets the password for the default username **developer**
+|
+|===
+
+NOTE: Variables marked with * are required while applying the addon, please check the <<apply-addon>> section for an example
+
+== Installing add-on
+
+Run the following command to install `htpasswd-identity-provider` add-on:
+
+[code,sh]
+----
+$ git clone https://github.com/minishift/minishift-addons
+$ minishift addon install ./minishift-addons/add-ons/htpasswd-identity-provider
+----
+
+[[apply-addon]]
+== Applying add-on
+
+To apply the addon run the following command,
+[code,sh]
+----
+$ minishift addon apply htpasswd-identity-provider --addon-env  USER_PASSWORD=superS3cret
+----
+
+== Undeploy add-on
+
+Removing the `htpasswd-identity-provider` add-on will be reverting the authentication policy to what minishift configures by default:
+
+Run the following command to remove the `htpasswd-identity-provider` add-on:
+
+[code,sh]
+----
+$ minishift addon remove htpasswd-identity-provider
+----
+
+== Uninstall htpasswd-identity-provider add-on
+
+Run the following command to delete and remove the `htpasswd-identity-provider` add-on artifacts from the machine:
+
+[code,sh]
+----
+$ minishift addon uninstall htpasswd-identity-provider
+----
+
+== Check and Verify Configuration
+
+The tool https://github.com/mikefarah/yq/[yq] allows performing YAML operations via the command line,  run the following command to check the configuration that was applied via this add-on:
+[code,sh]
+----
+$ minishift openshift config view | yq r - oauthConfig
+----

--- a/add-ons/htpasswd-identity-provider/htpasswd-identity-provider.addon
+++ b/add-ons/htpasswd-identity-provider/htpasswd-identity-provider.addon
@@ -1,0 +1,29 @@
+# Name: htpasswd-identity-provider
+# Description: Configures minishift to use HTPasswdIdentityProvider
+# Url: https://docs.openshift.org/3.9/install_config/configuring_authentication.html#HTPasswdPasswordIdentityProvider
+# Var-Defaults: USERNAME=developer,MINISHFIT_DATA_HOME=/var/lib/minishift,CONFIG_LOCATION=openshift.local.config/master,MASTER_CONFIG_FILE=master-config.yaml
+# Required-Vars: USER_PASSWORD,USERNAME,CONFIG_LOCATION
+
+# TODO remove hardcoded paths to ENV variables
+
+# backup the existing master-config.yaml
+ssh sudo cp -fp #{MINISHFIT_DATA_HOME}/#{CONFIG_LOCATION}/#{MASTER_CONFIG_FILE} #{MINISHFIT_DATA_HOME}/#{CONFIG_LOCATION}/master-config-htpasswd.yaml
+
+# create users.htpasswd file 
+ssh sudo touch #{MINISHFIT_DATA_HOME}/#{CONFIG_LOCATION}/users.htpasswd
+
+# add the default developer user to file
+ssh sudo htpasswd -b #{MINISHFIT_DATA_HOME}/#{CONFIG_LOCATION}/users.htpasswd #{USERNAME} #{USER_PASSWORD}
+
+# Patch the master configuration to use HTPasswdPasswordIdentityProvider
+ssh sudo grep "HTPasswdPasswordIdentityProvider" #{MINISHFIT_DATA_HOME}/#{CONFIG_LOCATION}/#{MASTER_CONFIG_FILE} > /dev/null || sudo #{MINISHFIT_DATA_HOME}/bin/oc ex config patch #{MINISHFIT_DATA_HOME}/#{CONFIG_LOCATION}/master-config-htpasswd.yaml --patch='{"oauthConfig": {"identityProviders": [ {"challenge": true,"login": true,"mappingMethod": "add","name": "htpasswd","provider": {"apiVersion": "v1","kind": "HTPasswdPasswordIdentityProvider","file": "users.htpasswd"}}]}}' > #{MINISHFIT_DATA_HOME}/#{CONFIG_LOCATION}/#{MASTER_CONFIG_FILE}
+
+# restart openshift 
+
+docker stop origin 
+docker start origin
+
+# remove the prepatch file
+ssh sudo rm -f #{MINISHFIT_DATA_HOME}/#{CONFIG_LOCATION}/master-config-htpasswd.yaml
+
+echo 'Successfully installed addon htpasswd identity provider'

--- a/add-ons/htpasswd-identity-provider/htpasswd-identity-provider.addon.remove
+++ b/add-ons/htpasswd-identity-provider/htpasswd-identity-provider.addon.remove
@@ -1,0 +1,20 @@
+# Name: htpasswd-identity-provider
+# Description: Reverts to default minishift authentication configuration
+# Url: https://docs.openshift.org/3.9/install_config/configuring_authentication.html#AllowAllPasswordIdentityProvider
+# Var-Defaults: MINISHFIT_DATA_HOME=/var/lib/minishift,CONFIG_LOCATION=openshift.local.config/master,MASTER_CONFIG_FILE=master-config.yaml
+# Required-Vars: CONFIG_LOCATION
+
+# backup existing configuration
+ssh sudo cp -fp #{MINISHFIT_DATA_HOME}/#{CONFIG_LOCATION}/#{MASTER_CONFIG_FILE} #{MINISHFIT_DATA_HOME}/#{CONFIG_LOCATION}/master-config-prepatch.yaml
+# revert to AllowAllPasswordIdentityProvider
+ssh sudo #{MINISHFIT_DATA_HOME}/bin/oc ex config patch #{MINISHFIT_DATA_HOME}/#{CONFIG_LOCATION}/master-config-prepatch.yaml --patch='{"oauthConfig": {"identityProviders": [ {"challenge": true,"login": true,"mappingMethod": "claim","name": "anypassword","provider": {"apiVersion": "v1","kind": "AllowAllPasswordIdentityProvider"}}]}}' > #{MINISHFIT_DATA_HOME}/#{CONFIG_LOCATION}/master-config.yaml
+# remove the prepatch file
+ssh sudo rm -f #{MINISHFIT_DATA_HOME}/#{CONFIG_LOCATION}/master-config-prepatch.yaml
+# remove users.htpasswd file 
+ssh sudo rm -f #{MINISHFIT_DATA_HOME}/#{CONFIG_LOCATION}/users.htpasswd
+
+# restart openshift 
+docker stop origin 
+docker start origin
+
+echo 'Successfully removed addon htpasswd-identity-provider'


### PR DESCRIPTION
Resolving Issue #133

This allows the minishift user to change the default `oauthConfig` to use `HTPasswdPasswordIdentityProvider`.

Signed-off-by: Kamesh Sampath <kamesh.sampath@hotmail.com>