### PR TITLE
Comment out new-project in grafana addon

### DIFF
--- a/add-ons/grafana/grafana.addon
+++ b/add-ons/grafana/grafana.addon
@@ -4,7 +4,7 @@
 # Required-Vars: namespace 
 
 # TODO: Once conditional commands are there, create the namespace if it does not exist
-oc adm new-project #{namespace}
+#oc adm new-project #{namespace}
 oc new-app -f openshift-template-persistent.yml -n #{namespace}
 
 echo You have installed #{addon-name}


### PR DESCRIPTION
Comment out new-project in grafana addon - grafana is often paired with Prometheus, but the new-project in the grafana addon hinders that.   Once conditionals are added, probably should test for whether the project namespace exists or not.