### PR TITLE
Removed double dashes from enable option on line 58

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -55,7 +55,7 @@ $ minishift addons apply <addon-name>
 - To enable the add-on to start each time that Minishift starts, run the following command:
 +
 ----
-$ minishift addons --enable <addon-name>
+$ minishift addons enable <addon-name>
 ----
 
 For more information about enabling, disabling, and applying add-ons, see the link:https://docs.openshift.org/latest/minishift/using/addons.html[Add-ons] topic in the Minishift documentation.


### PR DESCRIPTION
@rhoads-zach

The enable command, similar to apply, doesn't requite the --. Using the double dashes causes an error.