### PR TITLE
Issue #146 Remove oauth token from Eclipse Che addon

### DIFF
--- a/add-ons/che/README.md
+++ b/add-ons/che/README.md
@@ -77,16 +77,6 @@ $ eval $(minishift docker-env)
 $ docker build . -t eclipse/che-server:local
 ```
 
-#### Use a custom OpenShift token
-
-If you need to customize OpenShift token that is used by Che to access OpenShift API:
-
-```bash
-$ minishift addons apply --addon-env OPENSHIFT_TOKEN=$(oc whoami -t) che
-```
-
-You can use some specific token instead of using `$(oc whoami -t)` to get token of current user.
-
 #### Addon Variables
 
 To customize the deployment of the Che server, the following variables can be applied to the execution:
@@ -97,7 +87,6 @@ To customize the deployment of the Che server, the following variables can be ap
 |`CHE_DOCKER_IMAGE`|The docker image to be used for che.|`eclipse/che-server:latest`|
 |`GITHUB_CLIENT_ID`|GitHub client ID to be used in Che workspaces|`changeme`|
 |`GITHUB_CLIENT_SECRET`|GitHub client secred to be used in Che workspaces|`changeme`|
-|`OPENSHIFT_TOKEN`|For Che v6 only. The token to create workspace resources (pods, services, routes, etc...)|`changeme`|
 
 Variables can be specified by adding `--addon-env <key=value>` when the addon is being invoked (either by `minishift start` or `minishift addons apply`).
 

--- a/add-ons/che/che.addon
+++ b/add-ons/che/che.addon
@@ -13,7 +13,7 @@ oc adm new-project #{NAMESPACE} --description="Eclipse Che on minishift"
 oc adm policy add-role-to-user admin developer -n #{NAMESPACE}
 
 echo [CHE] Deploying Che on minishift
-oc new-app --param IMAGE_CHE_SERVER=#{CHE_DOCKER_IMAGE} --param PROJECT_NAME=#{NAMESPACE} --param DOMAIN_NAME=#{ip}.nip.io --param OPENSHIFT_OAUTH_TOKEN=#{OPENSHIFT_TOKEN} --param GITHUB_CLIENT_ID=#{GITHUB_CLIENT_ID} --param GITHUB_CLIENT_SECRET=#{GITHUB_CLIENT_SECRET} che-single-user -n #{NAMESPACE} 
+oc new-app --param IMAGE_CHE_SERVER=#{CHE_DOCKER_IMAGE} --param PROJECT_NAME=#{NAMESPACE} --param DOMAIN_NAME=#{ip}.nip.io --param GITHUB_CLIENT_ID=#{GITHUB_CLIENT_ID} --param GITHUB_CLIENT_SECRET=#{GITHUB_CLIENT_SECRET} che-single-user -n #{NAMESPACE} 
 
 echo Please wait while the pods all startup!
 echo You can watch in the OpenShift console via:

--- a/add-ons/che/templates/che-single-user.yml
+++ b/add-ons/che/templates/che-single-user.yml
@@ -26,10 +26,6 @@ parameters:
     name: IMAGE_CHE_SERVER
     value: "eclipse/che-server:latest"
     required: false
-  - displayName: OpenShift OAuth Token
-    description: Token to get access to the OpenShift API
-    name: OPENSHIFT_OAUTH_TOKEN
-    value: ""
   - displayName: GitHub client ID
     description: GitHub client ID
     name: GITHUB_CLIENT_ID
@@ -143,9 +139,6 @@ objects:
       bootstrapper-binary-url: "http://che-${PROJECT_NAME}.${DOMAIN_NAME}/agent-binaries/linux_amd64/bootstrapper/bootstrapper"
       machine-start-timeout-min: "5"
       openshift-master-url: ""
-      openshift-oauth-token: "${OPENSHIFT_OAUTH_TOKEN}"
-      openshift-username: ""
-      openshift-password: ""
       openshift-project: "${PROJECT_NAME}"
       pvc-strategy: "unique"
       openshift-trust-certs: "false"
@@ -402,16 +395,6 @@ objects:
                 configMapKeyRef:
                   key: openshift-master-url
                   name: che
-            - name: CHE_INFRA_OPENSHIFT_OAUTH__TOKEN
-              valueFrom:
-                configMapKeyRef:
-                  key: openshift-oauth-token
-                  name: che
-            - name: CHE_INFRA_OPENSHIFT_PASSWORD
-              valueFrom:
-                configMapKeyRef:
-                  key: openshift-password
-                  name: che
             - name: CHE_INFRA_OPENSHIFT_PROJECT
               valueFrom:
                 configMapKeyRef:
@@ -441,11 +424,6 @@ objects:
               valueFrom:
                 configMapKeyRef:
                   key: openshift-trust-certs
-                  name: che
-            - name: CHE_INFRA_OPENSHIFT_USERNAME
-              valueFrom:
-                configMapKeyRef:
-                  key: openshift-username
                   name: che
             - name: CHE_MULTIUSER
               valueFrom:

--- a/test/integration/che/che-steps.go
+++ b/test/integration/che/che-steps.go
@@ -35,7 +35,7 @@ func FeatureContext(s *godog.Suite) {
 		runner: cheAPI,
 	}
 
-	s.Step(`^applying che addon with openshift token succeeds$`, applyingCheWithOpenshiftTokenSucceeds)
+	s.Step(`^applying che addon succeeds$`, applyingCheSucceeds)
 
 	// steps for testing che addon
 	s.Step(`^user tries to get the che api endpoint$`, cheAPIRunner.weTryToGetTheCheApiEndpoint)

--- a/test/integration/che/che.go
+++ b/test/integration/che/che.go
@@ -25,14 +25,13 @@ import (
 	"github.com/minishift/minishift/test/integration/testsuite"
 )
 
-func applyingCheWithOpenshiftTokenSucceeds() error {
+func applyingCheSucceeds() error {
 	err := testsuite.MinishiftInstance.ExecutingOcCommand("whoami -t")
 	if err != nil {
 		return err
 	}
 
-	token := testsuite.GetLastCommandOutput().StdOut
-	err = testsuite.MinishiftInstance.ExecutingMinishiftCommand("addons apply --addon-env OPENSHIFT_TOKEN=" + token + " che")
+	err = testsuite.MinishiftInstance.ExecutingMinishiftCommand("addons apply che")
 
 	return err
 }

--- a/test/integration/features/che.feature
+++ b/test/integration/features/che.feature
@@ -17,7 +17,7 @@ Feature: Che add-on
     Then Minishift should have state "Running"
 
   Scenario: User applies Che add-on
-    When applying che addon with openshift token succeeds
+    When applying che addon succeeds
     Then stdout should contain "Please wait while the pods all startup!"
 
   Scenario: Che is ready


### PR DESCRIPTION
Removes references to using Eclipse Che with a user token, which as of PR https://github.com/eclipse/che/pull/10529 is removed from upstream.

Related issue: https://github.com/minishift/minishift-addons/issues/146